### PR TITLE
Add script for end-to-end training and S3 upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ AWS_DEFAULT_REGION=eu-north-1
 
 # Project Configuration
 AWS_S3_BUCKET=your-s3-bucket-name
+TITANIC_DATA_PATH=datasets/titanic.csv
+MODEL_S3_PATH=models/titanic_rf.pkl
 ENVIRONMENT=dev
 
 # MLflow Configuration (if needed)

--- a/README.md
+++ b/README.md
@@ -14,30 +14,24 @@
 
 ```
 AWS_S3_BUCKET=your-bucket-name
-TITANIC_DATA_KEY=datasets/titanic.csv
+TITANIC_DATA_PATH=datasets/titanic.csv
+MODEL_S3_PATH=models/titanic_rf.pkl
 ```
 
 ## Кроки
 
-### 1. Завантаження датасету в S3
+### 1. Повний пайплайн: завантаження датасету, тренування моделі та збереження в S3
 
-1. Змініть назву bucket у скрипті на ваш власний.
-2. Запустіть скрипт для завантаження датасету (створіть окремий скрипт або використайте AWS CLI):
-
-```bash
-aws s3 cp titanic.csv s3://<your-bucket-name>/datasets/titanic.csv
-```
-
-### 2. Тренування моделі та логування експерименту
-
-1. Вкажіть ваш bucket та ключ через змінні середовища (наприклад у `.env` файлі).
+1. Вкажіть ваш bucket та шляхи у `.env` файлі.
 2. Запустіть скрипт:
 
 ```bash
-python train_titanic.py
+python train_and_upload.py
 ```
 
-### 3. Запуск локального MLflow сервера
+Скрипт автоматично завантажить Titanic датасет, завантажить його в S3, натренує модель `RandomForestClassifier` та збереже її до S3 за шляхом `MODEL_S3_PATH`.
+
+### 2. Запуск локального MLflow сервера (опціонально)
 
 ```bash
 mlflow server --backend-store-uri ./mlruns --default-artifact-root ./mlruns --host 0.0.0.0 --port 5000
@@ -45,7 +39,7 @@ mlflow server --backend-store-uri ./mlruns --default-artifact-root ./mlruns --ho
 
 Інтерфейс MLflow буде доступний на [http://localhost:5000](http://localhost:5000).
 
-### 4. Перегляд результатів
+### 3. Перегляд результатів
 
 Всі експерименти, параметри, метрики та моделі будуть доступні через MLflow UI.
 

--- a/aws-titanic-ml/README.md
+++ b/aws-titanic-ml/README.md
@@ -37,8 +37,8 @@ aws-titanic-ml
    Export the required variables or copy `.env.example` to `.env` and fill in the values:
    ```
    AWS_S3_BUCKET=<your-s3-bucket>
-   TITANIC_DATA_KEY=<path-to-titanic-data>
-   MODEL_S3_KEY=<path-to-save-model>
+   TITANIC_DATA_PATH=<path-to-titanic-data>
+   MODEL_S3_PATH=<path-to-save-model>
    ```
 
 ## Usage
@@ -54,7 +54,7 @@ docker build -t aws-titanic-ml .
 
 To run the Docker container:
 ```bash
-docker run -e AWS_S3_BUCKET=<your-s3-bucket> -e TITANIC_DATA_KEY=<path-to-titanic-data> -e MODEL_S3_KEY=<path-to-save-model> aws-titanic-ml
+docker run -e AWS_S3_BUCKET=<your-s3-bucket> -e TITANIC_DATA_PATH=<path-to-titanic-data> -e MODEL_S3_PATH=<path-to-save-model> aws-titanic-ml
 ```
 
 ## License

--- a/config.py
+++ b/config.py
@@ -8,8 +8,8 @@ import os
 @dataclass
 class Settings:
     aws_s3_bucket: str
-    titanic_data_key: str = "datasets/titanic.csv"
-    model_s3_key: str = "models/titanic_rf.pkl"
+    titanic_data_path: str = "datasets/titanic.csv"
+    model_s3_path: str = "models/titanic_rf.pkl"
     mlflow_url: str = "http://127.0.0.1:5000"
     lambda_function_name: str = "titanic-train"
 
@@ -25,8 +25,8 @@ def _get_env(name: str, default: str | None = None) -> str:
 def get_settings() -> Settings:
     return Settings(
         aws_s3_bucket=_get_env("AWS_S3_BUCKET"),
-        titanic_data_key=os.environ.get("TITANIC_DATA_KEY", "datasets/titanic.csv"),
-        model_s3_key=os.environ.get("MODEL_S3_KEY", "models/titanic_rf.pkl"),
+        titanic_data_path=os.environ.get("TITANIC_DATA_PATH", "datasets/titanic.csv"),
+        model_s3_path=os.environ.get("MODEL_S3_PATH", "models/titanic_rf.pkl"),
         mlflow_url=os.environ.get("MLFLOW_URL", "http://127.0.0.1:5000"),
         lambda_function_name=os.environ.get("LAMBDA_FUNCTION_NAME", "titanic-train"),
     )

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -95,10 +95,10 @@ resource "aws_lambda_function" "titanic_train" {
 
   environment {
     variables = {
-      AWS_S3_BUCKET    = var.s3_bucket
-      TITANIC_DATA_KEY = var.titanic_data_key
-      MODEL_S3_KEY     = var.model_s3_key
-      PYTHONPATH       = "/opt/python"  # Important for Lambda to find the layer modules
+      AWS_S3_BUCKET     = var.s3_bucket
+      TITANIC_DATA_PATH = var.titanic_data_path
+      MODEL_S3_PATH     = var.model_s3_path
+      PYTHONPATH        = "/opt/python"  # Important for Lambda to find the layer modules
     }
   }
 

--- a/deploy/terraform.tfstate
+++ b/deploy/terraform.tfstate
@@ -150,8 +150,8 @@
               {
                 "variables": {
                   "AWS_S3_BUCKET": "mlflow-test-train",
-                  "MODEL_S3_KEY": "models/titanic_rf.pkl",
-                  "TITANIC_DATA_KEY": "datasets/titanic.csv"
+                  "MODEL_S3_PATH": "models/titanic_rf.pkl",
+                  "TITANIC_DATA_PATH": "datasets/titanic.csv"
                 }
               }
             ],

--- a/deploy/terraform.tfstate.backup
+++ b/deploy/terraform.tfstate.backup
@@ -150,8 +150,8 @@
               {
                 "variables": {
                   "AWS_S3_BUCKET": "mlflow-test-train",
-                  "MODEL_S3_KEY": "models/titanic_rf.pkl",
-                  "TITANIC_DATA_KEY": "datasets/titanic.csv"
+                  "MODEL_S3_PATH": "models/titanic_rf.pkl",
+                  "TITANIC_DATA_PATH": "datasets/titanic.csv"
                 }
               }
             ],

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -9,14 +9,14 @@ variable "s3_bucket" {
   type        = string
 }
 
-variable "titanic_data_key" {
-  description = "S3 key for Titanic dataset"
+variable "titanic_data_path" {
+  description = "S3 path for Titanic dataset"
   type        = string
   default     = "datasets/titanic.csv"
 }
 
-variable "model_s3_key" {
-  description = "S3 key for trained model"
+variable "model_s3_path" {
+  description = "S3 path for trained model"
   type        = string
   default     = "models/titanic_rf.pkl"
 }

--- a/main.py
+++ b/main.py
@@ -15,9 +15,9 @@ def invoke_lambda(lambda_name: str) -> bytes:
     return response["Payload"].read()
 
 
-def download_model(bucket: str, model_key: str, local_path: str) -> None:
+def download_model(bucket: str, model_path: str, local_path: str) -> None:
     s3 = boto3.client("s3")
-    s3.download_file(bucket, model_key, local_path)
+    s3.download_file(bucket, model_path, local_path)
     print(f"Downloaded model to {local_path}")
 
 
@@ -29,7 +29,7 @@ def main() -> None:
     download_titanic_csv()
     print("Titanic dataset downloaded successfully.")
 
-    upload_file("titanic.csv", settings.aws_s3_bucket, settings.titanic_data_key)
+    upload_file("titanic.csv", settings.aws_s3_bucket, settings.titanic_data_path)
     print("Titanic dataset uploaded to S3 successfully.")
     print("Run train_titanic.py to train the model.")
 
@@ -37,7 +37,7 @@ def main() -> None:
     print(invoke_lambda(settings.lambda_function_name))
 
     print("Downloading trained model...")
-    download_model(settings.aws_s3_bucket, settings.model_s3_key, "titanic_rf.pkl")
+    download_model(settings.aws_s3_bucket, settings.model_s3_path, "titanic_rf.pkl")
 
     print("Running prediction...")
     run_prediction("titanic.csv", "predictions.csv")

--- a/predict.py
+++ b/predict.py
@@ -12,7 +12,7 @@ def main(input_csv: str, output_csv: str) -> None:
     settings = get_settings()
 
     try:
-        model = load_pickle(settings.aws_s3_bucket, settings.model_s3_key)
+        model = load_pickle(settings.aws_s3_bucket, settings.model_s3_path)
     except (BotoCoreError, ClientError) as exc:
         raise RuntimeError("Failed to load model from S3") from exc
 

--- a/train_and_upload.py
+++ b/train_and_upload.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dotenv import load_dotenv
+from sklearn.ensemble import RandomForestClassifier
+
+from config import get_settings
+from download_titanic import download_titanic_csv
+from s3_utils import read_csv, save_pickle, upload_file
+
+
+def main() -> None:
+    load_dotenv()
+    settings = get_settings()
+
+    # Download dataset
+    download_titanic_csv()
+    print("Titanic dataset downloaded.")
+
+    # Upload dataset to S3
+    upload_file("titanic.csv", settings.aws_s3_bucket, settings.titanic_data_path)
+    print(
+        f"Titanic dataset uploaded to s3://{settings.aws_s3_bucket}/{settings.titanic_data_path}"
+    )
+
+    # Read dataset from S3
+    df = read_csv(settings.aws_s3_bucket, settings.titanic_data_path)
+    df = df.dropna(subset=["Survived", "Pclass", "Sex", "Age"])
+    df["Sex"] = df["Sex"].map({"male": 0, "female": 1})
+    X = df[["Pclass", "Sex", "Age"]]
+    y = df["Survived"]
+
+    # Train model
+    clf = RandomForestClassifier(n_estimators=100, random_state=42)
+    clf.fit(X, y)
+
+    # Save model to S3
+    save_pickle(clf, settings.aws_s3_bucket, settings.model_s3_path)
+    print(f"Model uploaded to s3://{settings.aws_s3_bucket}/{settings.model_s3_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train_titanic.py
+++ b/train_titanic.py
@@ -16,7 +16,7 @@ def main() -> None:
     settings = get_settings()
     mlflow.set_tracking_uri(settings.mlflow_url)
 
-    df = read_csv(settings.aws_s3_bucket, settings.titanic_data_key)
+    df = read_csv(settings.aws_s3_bucket, settings.titanic_data_path)
     df = df.dropna(subset=["Survived", "Pclass", "Sex", "Age"])
     df["Sex"] = df["Sex"].map({"male": 0, "female": 1})
     X = df[["Pclass", "Sex", "Age"]]

--- a/train_titanic_lambda.py
+++ b/train_titanic_lambda.py
@@ -11,7 +11,7 @@ def lambda_handler(event, context):
     load_dotenv()
     settings = get_settings()
 
-    df = read_csv(settings.aws_s3_bucket, settings.titanic_data_key)
+    df = read_csv(settings.aws_s3_bucket, settings.titanic_data_path)
     df = df.dropna(subset=["Survived", "Pclass", "Sex", "Age"])
     df["Sex"] = df["Sex"].map({"male": 0, "female": 1})
     X = df[["Pclass", "Sex", "Age"]]
@@ -20,5 +20,5 @@ def lambda_handler(event, context):
     clf = RandomForestClassifier(n_estimators=100, random_state=42)
     clf.fit(X, y)
 
-    save_pickle(clf, settings.aws_s3_bucket, settings.model_s3_key)
-    return {"status": "ok", "model_key": settings.model_s3_key}
+    save_pickle(clf, settings.aws_s3_bucket, settings.model_s3_path)
+    return {"status": "ok", "model_path": settings.model_s3_path}

--- a/upload_to_s3.py
+++ b/upload_to_s3.py
@@ -11,11 +11,11 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Upload a file to S3")
     parser.add_argument("local_path", nargs="?", default="titanic.csv")
-    parser.add_argument("s3_key", nargs="?", default=settings.titanic_data_key)
+    parser.add_argument("s3_path", nargs="?", default=settings.titanic_data_path)
     args = parser.parse_args()
 
-    upload_file(args.local_path, settings.aws_s3_bucket, args.s3_key)
-    print(f"Uploaded {args.local_path} to s3://{settings.aws_s3_bucket}/{args.s3_key}")
+    upload_file(args.local_path, settings.aws_s3_bucket, args.s3_path)
+    print(f"Uploaded {args.local_path} to s3://{settings.aws_s3_bucket}/{args.s3_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `train_and_upload.py` to download dataset, train a model, and upload artifacts to S3
- document pipeline usage and environment variables in README
- rename S3 environment variables to `TITANIC_DATA_PATH` and `MODEL_S3_PATH`

## Testing
- `black config.py train_and_upload.py train_titanic.py train_titanic_lambda.py main.py upload_to_s3.py predict.py`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894456e5604832abf1a837d0282835f