### PR TITLE
Add Lambda prediction script for random test passenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 AWS_S3_BUCKET=your-bucket-name
 TITANIC_DATA_PATH=datasets/titanic.csv
 MODEL_S3_PATH=models/titanic_rf.pkl
+LAMBDA_FUNCTION_NAME=titanic-train
 ```
 
 ## Кроки
@@ -24,7 +25,7 @@ MODEL_S3_PATH=models/titanic_rf.pkl
 
 Налаштуйте Amazon Lambda
 ```bash
-bash deploy/deploy_lambda.sh 
+bash deploy/deploy_lambda.sh
 ```
 
 ### 1. Повний пайплайн: завантаження датасету, тренування моделі та збереження в S3
@@ -52,6 +53,16 @@ mlflow server --backend-store-uri ./mlruns --default-artifact-root ./mlruns --ho
 ### 3. Перегляд результатів
 
 Всі експерименти, параметри, метрики та моделі будуть доступні через MLflow UI.
+
+### 4. Передбачення через Lambda
+
+```bash
+uv run predict_lambda.py
+```
+
+Скрипт випадково обирає пасажира з тестової вибірки Titanic, виводить його дані,
+викликає Lambda-функцію `LAMBDA_FUNCTION_NAME` і показує як передбачення, так і
+фактичний результат.
 
 ---
 

--- a/predict.py
+++ b/predict.py
@@ -17,6 +17,7 @@ def main(input_csv: str, output_csv: str) -> None:
         raise RuntimeError("Failed to load model from S3") from exc
 
     df = pd.read_csv(input_csv)
+    df = df.dropna(subset=["Pclass", "Sex", "Age"])
     df["Sex"] = df["Sex"].map({"male": 0, "female": 1})
     X = df[["Pclass", "Sex", "Age"]]
     preds = model.predict(X)

--- a/predict_lambda.py
+++ b/predict_lambda.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import random
+import boto3
+from dotenv import load_dotenv
+from sklearn.model_selection import train_test_split
+
+from config import get_settings
+from s3_utils import read_csv
+
+
+def main() -> None:
+    load_dotenv()
+    settings = get_settings()
+
+    df = read_csv(settings.aws_s3_bucket, settings.titanic_data_path)
+    df = df.dropna(subset=["Survived", "Pclass", "Sex", "Age"])
+
+    info_cols = ["Name", "Pclass", "Sex", "Age", "Survived"]
+    info_df = df[info_cols].copy()
+
+    df["Sex"] = df["Sex"].map({"male": 0, "female": 1})
+    X = df[["Pclass", "Sex", "Age"]]
+    y = df["Survived"]
+
+    _, X_test, _, _, _, info_test = train_test_split(
+        X, y, info_df, test_size=0.2, random_state=42
+    )
+
+    idx = random.randrange(len(X_test))
+    features = X_test.iloc[idx]
+    person = info_test.iloc[idx]
+
+    print("Random test passenger:")
+    print(f"Name: {person['Name']}")
+    print(f"Pclass: {person['Pclass']}")
+    print(f"Sex: {person['Sex']}")
+    print(f"Age: {person['Age']}")
+
+    payload = {
+        "Pclass": int(features["Pclass"]),
+        "Sex": int(features["Sex"]),
+        "Age": float(features["Age"]),
+    }
+
+    client = boto3.client("lambda")
+    response = client.invoke(
+        FunctionName=settings.lambda_function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(payload).encode(),
+    )
+    result = json.loads(response["Payload"].read())
+    prediction = int(result.get("prediction", 0))
+
+    pred_str = "survived" if prediction == 1 else "did not survive"
+    actual_str = "survived" if int(person["Survived"]) == 1 else "did not survive"
+    print(f"Lambda prediction: passenger {pred_str}.")
+    print(f"Actual outcome: passenger {actual_str}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- drop rows with missing features before running S3 model predictions
- add script to invoke Lambda for a random test passenger and compare prediction to true outcome
- document lambda prediction workflow in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689450cbd170832a8181a97f001e994a